### PR TITLE
simple spinning ticket lock

### DIFF
--- a/locks/ticket.zig
+++ b/locks/ticket.zig
@@ -17,7 +17,7 @@ const sync = @import("../sync.zig");
 const spinLoopHint = sync.spinLoopHint;
 
 pub const Lock = extern struct {
-    pub const name = "spin_lock";
+    pub const name = "ticket_lock";
 
     ticket: u16,
     owner: u16,

--- a/locks/ticket.zig
+++ b/locks/ticket.zig
@@ -1,0 +1,54 @@
+// Copyright (c) 2020 kprotty
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const std = @import("std");
+const sync = @import("../sync.zig");
+const spinLoopHint = sync.spinLoopHint;
+
+pub const Lock = extern struct {
+    pub const name = "spin_lock";
+
+    ticket: u16,
+    owner: u16,
+
+    pub fn init(self: *Lock) void {
+        self.ticket = 0;
+        self.owner = 0;
+    }
+
+    pub fn deinit(self: *Lock) void {
+        self.* = undefined;
+    }
+
+    pub fn withLock(self: *Lock, context: anytype) void {
+        self.acquire();
+        context.run();
+        self.release();
+    }
+
+    fn acquire(self: *Lock) void {
+        const ticket = @atomicRmw(u16, &self.ticket, .Add, 1, .Monotonic);
+        while (true) {
+            const owner = @atomicLoad(u16, &self.owner, .Acquire);
+            if (owner == ticket)
+                return;
+            spinLoopHint();
+        }
+    }
+
+    fn release(self: *Lock) void {
+        const owner = self.owner;
+        @atomicStore(u16, &self.owner, owner +% 1, .Release);
+    }
+};


### PR DESCRIPTION
Create a ticket lock to be used in order to benchmark fairness one bench.zig compiles.
The ticket lock currently spins to yield without exponential backoff, but there could be options to implement something like parking_lot with it in the future.