### PR TITLE
add exponential backoff spinning to spin_lock

### DIFF
--- a/sync.zig
+++ b/sync.zig
@@ -26,3 +26,11 @@ pub fn spinLoopHint(iters: usize) void {
         }
     }
 }
+
+pub fn yield() void {
+    if (std.builtin.os.tag == .windows) {
+        std.os.windows.kernel32.Sleep(0);   
+    } else {
+        std.os.sched_yield() catch unreachable;
+    }
+}


### PR DESCRIPTION
Spinning with backoff can reduce contention on the cache-line which improves throughput. Another throughput improvement is yielding to another thread (whether on the system with windows, or on the core with linux) which gives a chance for the lock holder to unlock it if they were preempted by eventually scheduling them for execution without spinning.